### PR TITLE
FIX:Can not connection to http://elasticsearch:9200

### DIFF
--- a/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/7.x-docker-2-es-instances/docker-compose.yaml
+++ b/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/7.x-docker-2-es-instances/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.seed_hosts=es7_01
+      - network.publish_host=elasticsearch
       - cluster.initial_master_nodes=es7_01,es7_02
     ulimits:
       memlock:


### PR DESCRIPTION
Hi,
在极客时间　《Elasticsearch核心技术与实战》 视频教学的第７节课中介绍使用 docker-compose 启动多个es 相关实例，我在测试学习的过程中发现有人和我有同样的问题，出现了 cannot connect to http://elasticsearch:9200 的异常，导致 kibana 无法正常启动，cerebro也无法正常检测，我似乎找到了问题的所在，但好像不是所有人都会遇到这个问题。希望提交这个 pull request 来解决这个问题。谢谢。