### PR TITLE
Fix the master_not_discovered_exception when launching ElasticSearch …

### DIFF
--- a/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/docker-es-7.2/docker-compose.yaml
+++ b/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/docker-es-7.2/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.seed_hosts=es72_01,es72_02
-      - network.publish_host=elasticsearch
       - cluster.initial_master_nodes=es72_01,es72_02
     ulimits:
       memlock:
@@ -51,7 +50,6 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.seed_hosts=es72_01,es72_02
-      - network.publish_host=elasticsearch
       - cluster.initial_master_nodes=es72_01,es72_02
     ulimits:
       memlock:


### PR DESCRIPTION
…7.2 from docker.

See https://time.geekbang.org/discuss/detail/120651

Signed-off-by: Wei Ren <wrn@amazon.com>