### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/docker-es-7.2/docker-compose.yaml
+++ b/part-1/2.3-在Docker容器中运行Elasticsearch,Kibana和Cerebro/docker-es-7.2/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.seed_hosts=es72_01,es72_02
-      - network.publish_host=elasticsearch
+      #- network.publish_host=elasticsearch
       - cluster.initial_master_nodes=es72_01,es72_02
     ulimits:
       memlock:
@@ -51,7 +51,7 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.seed_hosts=es72_01,es72_02
-      - network.publish_host=elasticsearch
+      #- network.publish_host=elasticsearch
       - cluster.initial_master_nodes=es72_01,es72_02
     ulimits:
       memlock:


### PR DESCRIPTION
fix cerebro can't connect to http://elasticsearch:9200 error on mac

after git clone this repo , if derectly run docker-compose up 
kibana will not successfully started because it can't connect to http://elasticsearch:9200
and cerebro will also failed when you try to connect http://elasticsearch:9200