### PR TITLE
[FIX] remove useless mutate for logstash

### DIFF
--- a/part-1/2.4-Logstash安装与导入数据/movielens/logstash.conf
+++ b/part-1/2.4-Logstash安装与导入数据/movielens/logstash.conf
@@ -13,7 +13,6 @@ filter {
 
   mutate {
     split => { "genre" => "|" }
-    remove_field => ["path", "host","@timestamp","message"]
   }
 
   mutate {


### PR DESCRIPTION
The `remove_field` duplicated with [L30](https://github.com/geektime-geekbang/geektime-ELK/compare/master...robturtle:fix-logstash-config?expand=1#diff-bd5caccf6ca07eed5c194c25ec0ca227R30)